### PR TITLE
fix: remove gaps left over from homepage shelves

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -95,20 +95,11 @@ async function main() {
   let aggressiveMode = getLocalStorageDataFromKey(AGGRESSIVE_MODE_KEY, false);
   let hideAudioBooks = getLocalStorageDataFromKey(AUDIOBOOKS_KEY, false);
 
-  const hideAudiobooksMenuItem = new Menu.Item(t('menu.hideAudiobooks'), hideAudioBooks, (self) => {
-    hideAudioBooks = !hideAudioBooks;
-    localStorage.setItem(AUDIOBOOKS_KEY, hideAudioBooks);
-    // self.setState(isEnabled && hideAudioBooks);
-    self.setState(hideAudioBooks);
-    apply();
-  });
-
   // Add menu item and menu click handler
   const enabledMenuItem = new Menu.Item(t('menu.enabled'), isEnabled, (self) => {
     isEnabled = !isEnabled;
     localStorage.setItem(SETTINGS_KEY, isEnabled);
     self.setState(isEnabled);
-    // hideAudiobooksMenuItem.setState(isEnabled && hideAudioBooks);
     apply();
   });
 
@@ -119,11 +110,18 @@ async function main() {
     location.reload();
   });
 
-  new Menu.SubMenu(t('menu.title'), Object.values([
+  const hideAudiobooksMenuItem = new Menu.Item(t('menu.hideAudiobooks'), hideAudioBooks, (self) => {
+    hideAudioBooks = !hideAudioBooks;
+    localStorage.setItem(AUDIOBOOKS_KEY, hideAudioBooks);
+    self.setState(hideAudioBooks);
+    apply();
+  });
+
+  new Menu.SubMenu(t('menu.title'), [
     enabledMenuItem,
     aggressiveModeMenuItem,
     hideAudiobooksMenuItem,
-  ])).register();
+  ]).register();
 
   // Run the app logic
   function apply() {

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -12,7 +12,11 @@ $familyDramaEpisodesForYou: '0JQ5DAnM3wGh0gz1MXnujZ';
 $currentEventsEpisodesForYou: '0JQ5DAnM3wGh0gz1MXnuk3';
 $showsToTry: '0JQ5DAnM3wGh0gz1MXnu3L';
 
-// The nearby shelves seem to freak out and constantly recalculate their positions if I use display: none
+// The nearby shelves seem to freak out and constantly show/hide if I use display:none, since
+// React culls the elements and the :has selector no longer applies,
+// causing the shelves to be visible again. Then it culls them again, and so on.
+// If I use visiblity instead, it does hide them, but since the element is still technically there,
+// it leaves behind the `gap` in the grid.
 @mixin hide-visibility {
   visibility: hidden;
   height: 0;
@@ -36,15 +40,14 @@ $showsToTry: '0JQ5DAnM3wGh0gz1MXnu3L';
   };
 
   // Fallback for shelves that have podcasts in them
-  // NOTE: These leave behind the `gap` from the grid, since the element is still there
-  // If I use display:none, react removes the elements these apply to, so these :has rules no longer apply, and it flashes visible/hidden
+  // (These leave behind a gap)
   .main-shelf-shelf:has(a[href^="/episode/"]),
   .main-shelf-shelf:has(a[href^="/show/"]) {
     @include hide-visibility();
   }
 
   // Specific shelves that have podcasts in them
-  // These do work, since the link element doesn't get removed when display:none;
+  // (These don't leave a gap)
   .main-shelf-shelf:has(a[href*="#{$spotifyOriginalPodcasts}"]),
   .main-shelf-shelf:has(a[href*="#{$episodesForYou}"]),
   .main-shelf-shelf:has(a[href*="#{$geopoliticalAnalysisEpisodesForYou}"]),
@@ -86,7 +89,7 @@ $showsToTry: '0JQ5DAnM3wGh0gz1MXnu3L';
   }
 
   // Specific shelves that have audiobooks in them
-  // These do work, since the link element doesn't get removed when display:none;
+  // (These don't leave a gap)
   .main-shelf-shelf:has(a[href*="#{$audiobooksForYou}"]) {
     @include hide-display();
   }

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -1,5 +1,17 @@
 // TODO: Make a debug switch that just outlines everything it would block in red.
 
+// IDs for audiobooks (href="/section/ID")
+$audiobooksForYou: '0JQ5DAnM3wGh0gz1MXnue2';
+// IDs for podcasts
+$spotifyOriginalPodcasts: '0JQ5DAnM3wGh0gz1MXnu4i';
+$episodesForYou: '0JQ5DAnM3wGh0gz1MXnu9e';
+$geopoliticalAnalysisEpisodesForYou: '0JQ5DAnM3wGh0gz1MXnuk0';
+$mediaScrutinyEpisodesForYou: '0JQ5DAnM3wGh0gz1MXnuk1';
+$UKPoliticsEpisodesForYou: '0JQ5DAnM3wGh0gz1MXnuk2';
+$familyDramaEpisodesForYou: '0JQ5DAnM3wGh0gz1MXnujZ';
+$currentEventsEpisodesForYou: '0JQ5DAnM3wGh0gz1MXnuk3';
+$showsToTry: '0JQ5DAnM3wGh0gz1MXnu3L';
+
 // The nearby shelves seem to freak out and constantly recalculate their positions if I use display: none
 @mixin hide-visibility {
   visibility: hidden;
@@ -23,10 +35,25 @@
     @include hide-display();
   };
 
-  // Shelves that have podcasts in them
+  // Fallback for shelves that have podcasts in them
+  // NOTE: These leave behind the `gap` from the grid, since the element is still there
+  // If I use display:none, react removes the elements these apply to, so these :has rules no longer apply, and it flashes visible/hidden
   .main-shelf-shelf:has(a[href^="/episode/"]),
   .main-shelf-shelf:has(a[href^="/show/"]) {
     @include hide-visibility();
+  }
+
+  // Specific shelves that have podcasts in them
+  // These do work, since the link element doesn't get removed when display:none;
+  .main-shelf-shelf:has(a[href*="#{$spotifyOriginalPodcasts}"]),
+  .main-shelf-shelf:has(a[href*="#{$episodesForYou}"]),
+  .main-shelf-shelf:has(a[href*="#{$geopoliticalAnalysisEpisodesForYou}"]),
+  .main-shelf-shelf:has(a[href*="#{$mediaScrutinyEpisodesForYou}"]),
+  .main-shelf-shelf:has(a[href*="#{$UKPoliticsEpisodesForYou}"]),
+  .main-shelf-shelf:has(a[href*="#{$familyDramaEpisodesForYou}"]),
+  .main-shelf-shelf:has(a[href*="#{$currentEventsEpisodesForYou}"]),
+  .main-shelf-shelf:has(a[href*="#{$showsToTry}"]) {
+    @include hide-display();
   }
 
   // Podcasts categories on search page
@@ -55,6 +82,12 @@
 .hide-audiobooks-enabled {
   // Items I've tagged via JS
   .audiobook-item {
+    @include hide-display();
+  }
+
+  // Specific shelves that have audiobooks in them
+  // These do work, since the link element doesn't get removed when display:none;
+  .main-shelf-shelf:has(a[href*="#{$audiobooksForYou}"]) {
     @include hide-display();
   }
 


### PR DESCRIPTION
The nearby shelves seem to freak out and constantly show/hide if I use display:none, since React culls the elements and the `:has` selector no longer applies, causing the shelves to be visible again. Then it culls them again, and so on.
If I use visiblity instead, it does hide them, but since the element is still technically there, it leaves behind the `gap` in the grid. 

React seems to leave behind the links when it culls, so I can safely use the link `href`s to target specific playlists. I'll just need to keep a list of them, and update any missing. 