### PR TITLE
docs: record that `--notes` and `--generate-notes` do combine

### DIFF
--- a/.claude/skills/draft-release/SKILL.md
+++ b/.claude/skills/draft-release/SKILL.md
@@ -239,7 +239,11 @@ gh release create vX.Y.Z --draft --title "X.Y.Z" \
 `--generate-notes` appends GitHub's `## What's Changed`, `## New Contributors` and
 `**Full Changelog**` below your prose, which is how 3.2.0's body was built. Use
 `--notes`, not `--notes-file`: gh documents the prepending behaviour for `--notes`
-only.
+only. **Confirmed working** — this is exactly how v3.2.1 was cut, in one command.
+
+Pass `--title` even though it looks redundant: `gh` prints an `untagged-<hash>`
+URL when it creates a draft, because a draft's tag does not exist yet. That is
+normal and not a sign the tag was missed — `gh release view vX.Y.Z` resolves fine.
 
 **No release assets.** Unlike the sibling name-that-tune repo, no release here has
 ever carried a zip — 3.0.0 through 3.2.0 all have none. Users copy `hidePodcasts.js`


### PR DESCRIPTION
Small follow-up from cutting v3.2.1, which was the `draft-release` skill's first real run.

The skill listed one open question: whether `gh release create` combines `--notes` with `--generate-notes`, since gh's docs describe prepending for `--notes` only and testing it meant creating a real draft release. Cutting 3.2.1 answered it — they combine in a single command, prose first and GitHub's `## What's Changed` / `**Full Changelog**` below.

Also records that `gh release create --draft` prints an `untagged-<hash>` URL, which reads like the tag was missed. It wasn't: a draft's tag doesn't exist server-side yet, and `gh release view vX.Y.Z` resolves normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoBesJhk6w8BncF2aYBy3x